### PR TITLE
Fix crash when fragments are restored

### DIFF
--- a/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/service/DaggerAbstractInputMethodService.java
+++ b/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/service/DaggerAbstractInputMethodService.java
@@ -17,14 +17,14 @@ public abstract class DaggerAbstractInputMethodService extends AbstractInputMeth
 
 	@Override
 	public void onCreate() {
-		super.onCreate();
 		mHelper.onCreate(this, getModules());
+		super.onCreate();
 	}
 
 	@Override
 	public void onDestroy() {
-		mHelper.onDestroy();
 		super.onDestroy();
+		mHelper.onDestroy();
 	}
 
 	protected abstract List<Object> getModules();

--- a/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/service/DaggerDreamService.java
+++ b/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/service/DaggerDreamService.java
@@ -20,14 +20,14 @@ public abstract class DaggerDreamService extends DreamService implements DaggerC
 
 	@Override
 	public void onCreate() {
-		super.onCreate();
 		mHelper.onCreate(this, getModules());
+		super.onCreate();
 	}
 
 	@Override
 	public void onDestroy() {
-		mHelper.onDestroy();
 		super.onDestroy();
+		mHelper.onDestroy();
 	}
 
 	protected abstract List<Object> getModules();

--- a/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/service/DaggerIntentService.java
+++ b/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/service/DaggerIntentService.java
@@ -22,14 +22,14 @@ public abstract class DaggerIntentService extends IntentService implements Dagge
 
 	@Override
 	public void onCreate() {
-		super.onCreate();
 		mHelper.onCreate(this, getModules());
+		super.onCreate();
 	}
 
 	@Override
 	public void onDestroy() {
-		mHelper.onDestroy();
 		super.onDestroy();
+		mHelper.onDestroy();
 	}
 
 	@Override

--- a/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/service/DaggerService.java
+++ b/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/service/DaggerService.java
@@ -19,14 +19,14 @@ public abstract class DaggerService extends Service implements DaggerContext {
 
 	@Override
 	public void onCreate() {
-		super.onCreate();
 		mHelper.onCreate(this, getModules());
+		super.onCreate();
 	}
 
 	@Override
 	public void onDestroy() {
-		mHelper.onDestroy();
 		super.onDestroy();
+		mHelper.onDestroy();
 	}
 
 	@Override

--- a/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/service/DaggerWallpaperService.java
+++ b/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/service/DaggerWallpaperService.java
@@ -17,14 +17,14 @@ public abstract class DaggerWallpaperService extends WallpaperService implements
 
 	@Override
 	public void onCreate() {
-		super.onCreate();
 		mHelper.onCreate(this, getModules());
+		super.onCreate();
 	}
 
 	@Override
 	public void onDestroy() {
-		mHelper.onDestroy();
 		super.onDestroy();
+		mHelper.onDestroy();
 	}
 
 	protected abstract List<Object> getModules();

--- a/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/ui/DaggerAccountAuthenticatorActivity.java
+++ b/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/ui/DaggerAccountAuthenticatorActivity.java
@@ -24,8 +24,8 @@ public abstract class DaggerAccountAuthenticatorActivity extends AccountAuthenti
 
 	@Override
 	protected void onDestroy() {
-		mHelper.onDestroy();
 		super.onDestroy();
+		mHelper.onDestroy();
 	}
 
 	protected abstract List<Object> getModules();

--- a/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/ui/DaggerActivity.java
+++ b/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/ui/DaggerActivity.java
@@ -24,8 +24,8 @@ public abstract class DaggerActivity extends Activity implements DaggerContext {
 
 	@Override
 	protected void onDestroy() {
-		mHelper.onDestroy();
 		super.onDestroy();
+		mHelper.onDestroy();
 	}
 
 	protected abstract List<Object> getModules();

--- a/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/ui/DaggerListActivity.java
+++ b/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/ui/DaggerListActivity.java
@@ -24,8 +24,8 @@ public abstract class DaggerListActivity extends ListActivity implements DaggerC
 
 	@Override
 	protected void onDestroy() {
-		mHelper.onDestroy();
 		super.onDestroy();
+		mHelper.onDestroy();
 	}
 
 	protected abstract List<Object> getModules();

--- a/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/ui/DaggerPreferenceActivity.java
+++ b/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/ui/DaggerPreferenceActivity.java
@@ -24,8 +24,8 @@ public abstract class DaggerPreferenceActivity extends PreferenceActivity implem
 
 	@Override
 	protected void onDestroy() {
-		mHelper.onDestroy();
 		super.onDestroy();
+		mHelper.onDestroy();
 	}
 
 	protected abstract List<Object> getModules();

--- a/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/ui/v4/DaggerAccountAuthenticatorFragmentActivity.java
+++ b/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/ui/v4/DaggerAccountAuthenticatorFragmentActivity.java
@@ -17,14 +17,14 @@ public abstract class DaggerAccountAuthenticatorFragmentActivity extends Account
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
 		mHelper.onCreate(this, getModules());
+		super.onCreate(savedInstanceState);
 	}
 
 	@Override
 	protected void onDestroy() {
-		mHelper.onDestroy();
 		super.onDestroy();
+		mHelper.onDestroy();
 	}
 
 	protected abstract List<Object> getModules();

--- a/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/ui/v4/DaggerFragmentActivity.java
+++ b/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/ui/v4/DaggerFragmentActivity.java
@@ -18,14 +18,14 @@ public abstract class DaggerFragmentActivity extends FragmentActivity implements
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
 		mHelper.onCreate(this, getModules());
+		super.onCreate(savedInstanceState);
 	}
 
 	@Override
 	protected void onDestroy() {
-		mHelper.onDestroy();
 		super.onDestroy();
+		mHelper.onDestroy();
 	}
 
 	protected abstract List<Object> getModules();

--- a/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/ui/v7/DaggerAccountAuthenticatorActionBarActivity.java
+++ b/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/ui/v7/DaggerAccountAuthenticatorActionBarActivity.java
@@ -17,14 +17,14 @@ public abstract class DaggerAccountAuthenticatorActionBarActivity extends Accoun
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
 		mHelper.onCreate(this, getModules());
+		super.onCreate(savedInstanceState);
 	}
 
 	@Override
 	protected void onDestroy() {
-		mHelper.onDestroy();
 		super.onDestroy();
+		mHelper.onDestroy();
 	}
 
 	protected abstract List<Object> getModules();

--- a/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/ui/v7/DaggerActionBarActivity.java
+++ b/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/ui/v7/DaggerActionBarActivity.java
@@ -18,14 +18,14 @@ public abstract class DaggerActionBarActivity extends ActionBarActivity implemen
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
 		mHelper.onCreate(this, getModules());
+		super.onCreate(savedInstanceState);
 	}
 
 	@Override
 	protected void onDestroy() {
-		mHelper.onDestroy();
 		super.onDestroy();
+		mHelper.onDestroy();
 	}
 
 	protected abstract List<Object> getModules();


### PR DESCRIPTION
Activity and FragmentActivity restore previously attached Fragments in onCreate() call.
So `Fragment#onCreate()` will be called on first line (`super.onCreate(savedInstanceState)`) of activity's onCreate().
This leads `DaggerContext#inject()` in DaggerFragmnet to be called before `mHelper.onCreate()` in its hosting activity.

```
     Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Object dagger.ObjectGraph.inject(java.lang.Object)' on a null object reference
            at com.anprosit.android.dagger.helper.DaggerHelper.inject(DaggerHelper.java:32)
            at com.anprosit.android.dagger.ui.v7.DaggerActionBarActivity.inject(DaggerActionBarActivity.java:35)
            at com.anprosit.android.dagger.ui.v4.DaggerFragment.onCreate(DaggerFragment.java:15)
            at us.mitene.app.setting.ui.SettingsFragment.onCreate(SettingsFragment.java:34)
            at android.support.v4.app.Fragment.performCreate(Fragment.java:1763)
            at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:913)
            at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:1126)
            at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:1108)
            at android.support.v4.app.FragmentManagerImpl.dispatchCreate(FragmentManager.java:1912)
            at android.support.v4.app.FragmentActivity.onCreate(FragmentActivity.java:266)
            at android.support.v7.app.ActionBarActivity.onCreate(ActionBarActivity.java:122)
            at com.anprosit.android.dagger.ui.v7.DaggerActionBarActivity.onCreate(DaggerActionBarActivity.java:21)
            at us.mitene.app.home.ui.HomeActivity.onCreate(HomeActivity.java:51)
            at android.app.Activity.performCreate(Activity.java:5933)
            at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1105)
            at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2251)
            at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2360)
            at android.app.ActivityThread.access$800(ActivityThread.java:144)
            at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1278)
            at android.os.Handler.dispatchMessage(Handler.java:102)
            at android.os.Looper.loop(Looper.java:135)
            at android.app.ActivityThread.main(ActivityThread.java:5221)
            at java.lang.reflect.Method.invoke(Native Method)
            at java.lang.reflect.Method.invoke(Method.java:372)
            at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:899)
            at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:694)
```

This PR fixes this by calling `super.onCreate()` just after `mHelper.onCrate()`.

onDestroy() has another issue, accessing to ObjectGraph after `super.onDestroy()` can cause crash.
So any cleanup should be done before super call.
As there is no workaround for this, I think it would be better to be documented.

Thank you for nice library! :)