### PR TITLE
Cast to DaggerContext instead of Application classes

### DIFF
--- a/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/helper/DaggerHelper.java
+++ b/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/helper/DaggerHelper.java
@@ -2,7 +2,7 @@ package com.anprosit.android.dagger.helper;
 
 import android.content.Context;
 
-import com.anprosit.android.dagger.application.DaggerApplication;
+import com.anprosit.android.dagger.DaggerContext;
 
 import java.util.List;
 
@@ -15,7 +15,7 @@ public class DaggerHelper {
 	private ObjectGraph mObjectGraph;
 
 	public void onCreate(Context context, List<Object> modules) {
-		DaggerApplication application = (DaggerApplication) context.getApplicationContext();
+		DaggerContext application = (DaggerContext) context.getApplicationContext();
 		mObjectGraph = application.getObjectGraph().plus(modules.toArray());
 
 		// Inject ourselves so subclasses will have dependencies fulfilled when this method returns.

--- a/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/receiver/DaggerBroadcastReceiver.java
+++ b/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/receiver/DaggerBroadcastReceiver.java
@@ -5,7 +5,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 
-import com.anprosit.android.dagger.application.DaggerApplication;
+import com.anprosit.android.dagger.DaggerContext;
 
 /**
  * @author hnakagawa
@@ -13,9 +13,8 @@ import com.anprosit.android.dagger.application.DaggerApplication;
 public abstract class DaggerBroadcastReceiver extends BroadcastReceiver {
 	@Override
 	public final void onReceive(Context context, Intent intent) {
-		DaggerApplication application = (DaggerApplication) context.getApplicationContext();
-		application.getObjectGraph().inject(this);
-		onHandleIntent(application, intent);
+		((DaggerContext) context.getApplicationContext()).getObjectGraph().inject(this);
+		onHandleIntent((Application) context.getApplicationContext(), intent);
 	}
 
 	public abstract void onHandleIntent(Application application, Intent intent);

--- a/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/receiver/DaggerWakefulBroadcastReceiver.java
+++ b/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/receiver/DaggerWakefulBroadcastReceiver.java
@@ -5,7 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.support.v4.content.WakefulBroadcastReceiver;
 
-import com.anprosit.android.dagger.application.DaggerApplication;
+import com.anprosit.android.dagger.DaggerContext;
 
 /**
  * @author KeithYokoma
@@ -13,9 +13,8 @@ import com.anprosit.android.dagger.application.DaggerApplication;
 public abstract class DaggerWakefulBroadcastReceiver extends WakefulBroadcastReceiver {
 	@Override
 	public final void onReceive(Context context, Intent intent) {
-		DaggerApplication application = (DaggerApplication) context.getApplicationContext();
-		application.getObjectGraph().inject(this);
-		onHandleIntent(application, intent);
+		((DaggerContext) context.getApplicationContext()).getObjectGraph().inject(this);
+		onHandleIntent((Application) context.getApplicationContext(), intent);
 	}
 
 	public abstract void onHandleIntent(Application application, Intent intent);


### PR DESCRIPTION
Currently DaggerHelper will throw a ClassCastException when the Application is extending DaggerMultiDexApplication.
This allows the use of DaggerMultiDexApplication.