### PR TITLE
Initialize ObjectGraph on Application#attachBaseContext

### DIFF
--- a/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/application/DaggerApplication.java
+++ b/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/application/DaggerApplication.java
@@ -1,6 +1,7 @@
 package com.anprosit.android.dagger.application;
 
 import android.app.Application;
+import android.content.Context;
 
 import com.anprosit.android.dagger.DaggerContext;
 
@@ -15,8 +16,9 @@ public abstract class DaggerApplication extends Application implements DaggerCon
 	private ObjectGraph mApplicationGraph;
 
 	@Override
-	public void onCreate() {
-		super.onCreate();
+	protected void attachBaseContext(Context base) {
+		super.attachBaseContext(base);
+
 		mApplicationGraph = ObjectGraph.create(getModules().toArray());
 		mApplicationGraph.inject(this);
 	}

--- a/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/application/DaggerMultiDexApplication.java
+++ b/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/application/DaggerMultiDexApplication.java
@@ -1,5 +1,6 @@
 package com.anprosit.android.dagger.application;
 
+import android.content.Context;
 import android.support.multidex.MultiDexApplication;
 
 import com.anprosit.android.dagger.DaggerContext;
@@ -15,8 +16,8 @@ public abstract class DaggerMultiDexApplication extends MultiDexApplication impl
 	private ObjectGraph mApplicationGraph;
 
 	@Override
-	public void onCreate() {
-		super.onCreate();
+	protected void attachBaseContext(Context base) {
+		super.attachBaseContext(base);
 
 		// Workaround for multidex
 		new Runnable() {


### PR DESCRIPTION
There are situations where the object graph has to be available during Application#getSystemService (in my particular case, for use with Mortar).
For example, when an application has ContentProviders, Application#getSystemService will be called during their initializations which happens to occur before Apllication#onCreate.